### PR TITLE
Update AppBar Title property documentation

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -287,11 +287,12 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// MaterialApp(
   ///   home: Scaffold(
   ///     appBar: AppBar(
-  ///        title: SizedBox(
-  ///        height: toolbarHeight,
-  ///        child: child: Image.asset(logoAsset),
-  ///      ),
-  ///      toolbarHeight: toolbarHeight,
+  ///       title: SizedBox(
+  ///         height: toolbarHeight,
+  ///         child: Image.asset(logoAsset),
+  ///       ),
+  ///       toolbarHeight: toolbarHeight,
+  ///     ),
   ///   ),
   /// )
   /// ```


### PR DESCRIPTION
Currently, there is an extraneous `child:` key and a missing closing parenthesis. This fix removes the extraneous `child:` key and adds the necessary parenthesis.

Source: https://api.flutter.dev/flutter/material/AppBar/title.html

![image](https://user-images.githubusercontent.com/6170077/110271170-17b84280-7f8d-11eb-9127-ec8079b98f8a.png)